### PR TITLE
[fix]ItemBaseをGearManagerのGearInfoリストに自分を追加するように修正しました。

### DIFF
--- a/Assets/ItemBase.cs
+++ b/Assets/ItemBase.cs
@@ -1,21 +1,44 @@
 using System;
 using UnityEngine;
+using UnityEngine.UI;
 public abstract class ItemBase : MonoBehaviour
 {
+    Text _text;
+    void Start()
+    {
+        _text = GetComponentInChildren<Text>();
+        _text.text =  $"{itemStruct.ItemName} {(int)itemStruct.ItemPrice}" ;
+        GearInfo gearInfo = new();
+        gearInfo.GearName = itemStruct.ItemName;
+        gearInfo.GearSps = itemStruct.ItemSps;
+        gearInfo.GearValue = 0;
+        GearManager.Instance.Gears.Add(gearInfo);
+    }
     const double _buyMag = 1.15;
     [Serializable]
     public struct ItemStruct
     {
         /// <summary>アイテムの名前。例：グランマ </summary>
         public string ItemName;
-        /// <summary>アイテムの最初の値段。例：100</summary>
+        /// <summary>アイテムの値段。例：100</summary>
         public double ItemPrice;
+        /// <summary>アイテムのsps。例：1</summary>
+        public float ItemSps;
     }
 
-    [SerializeField]protected ItemStruct itemStruct = new();
+    [SerializeField] protected ItemStruct itemStruct = new();
     public void MulIntemBuyMag() => itemStruct.ItemPrice *= _buyMag;
+
+    public bool IsBuy() => ScoreManager.Instance.Score > (int)itemStruct.ItemPrice;
+    
     public virtual void BoughItem()
     {
-        MulIntemBuyMag();
+        if (IsBuy())
+        {
+            ScoreManager.Instance.SubScore((int)itemStruct.ItemPrice);
+            MulIntemBuyMag();
+            GearManager.Instance.AddGear(itemStruct.ItemName);
+            _text.text = $"{itemStruct.ItemName} {(int)itemStruct.ItemPrice}";
+        }
     }
 }

--- a/Assets/ItemBase.cs
+++ b/Assets/ItemBase.cs
@@ -1,4 +1,4 @@
-using System;
+ï»¿using System;
 using UnityEngine;
 using UnityEngine.UI;
 public abstract class ItemBase : MonoBehaviour
@@ -18,11 +18,11 @@ public abstract class ItemBase : MonoBehaviour
     [Serializable]
     public struct ItemStruct
     {
-        /// <summary>ƒAƒCƒeƒ€‚Ì–¼‘OB—áFƒOƒ‰ƒ“ƒ} </summary>
+        /// <summary>ã‚¢ã‚¤ãƒ†ãƒ ã®åå‰ã€‚ä¾‹ï¼šã‚°ãƒ©ãƒ³ãƒ </summary>
         public string ItemName;
-        /// <summary>ƒAƒCƒeƒ€‚Ì’l’iB—áF100</summary>
+        /// <summary>ã‚¢ã‚¤ãƒ†ãƒ ã®å€¤æ®µã€‚ä¾‹ï¼š100</summary>
         public double ItemPrice;
-        /// <summary>ƒAƒCƒeƒ€‚ÌspsB—áF1</summary>
+        /// <summary>ã‚¢ã‚¤ãƒ†ãƒ ã®spsã€‚ä¾‹ï¼š1</summary>
         public float ItemSps;
     }
 


### PR DESCRIPTION
Buttonにアタッチして各パラメータをいれれば、場にGearManagerがある場合スコアを使って買うことができます。
Bottunの子についているTextで各パラメータを表示するように修正しました。
※ItemBaseは継承して使う必要があります。