### PR TITLE
[add,fix]UpGradeの追加,TextMeshPro用にスクリプトを一部変更,ゲーム開始時にScoreと施設リストが変更されていない部分を修正

### DIFF
--- a/Assets/GameManager.cs
+++ b/Assets/GameManager.cs
@@ -7,8 +7,8 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager Instance;
 
-    [SerializeField] Text _scoreText;
-    [SerializeField] List<Text> _gearListText = new List<Text>();
+    [SerializeField] TMP_Text _scoreText;
+    [SerializeField] List<TMP_Text> _gearListText = new List<TMP_Text>();
     float _clickMulti = 1;
     public float ClickMulti { get { return _clickMulti; } }
     private void Awake()
@@ -22,7 +22,8 @@ public class GameManager : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        
+        ScoreUpdate();
+        GearsListTextUpdate();
     }
 
     // Update is called once per frame

--- a/Assets/GearManager.cs
+++ b/Assets/GearManager.cs
@@ -44,6 +44,7 @@ public class GearManager : MonoBehaviour
         if (_gears.Count > 1)
         {
             _gears.Sort((A, B) => A.GearSps.CompareTo(B.GearSps));
+            GameManager.Instance.GearsListTextUpdate();
         }
     }
 

--- a/Assets/UpGrade.cs
+++ b/Assets/UpGrade.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class UpGrade : MonoBehaviour
+{
+    [SerializeField] int _price;
+    [SerializeField] string[] _upGradeGears;
+    [SerializeField] string _UpGradeNameText;
+
+    private void Start()
+    {
+        GetComponentInChildren<TMP_Text>().text = $"{_UpGradeNameText} {_price}";
+    }
+
+    public void BoughUpGrade()
+    {
+        if(ScoreManager.Instance.Score > _price)
+        {
+            ScoreManager.Instance.SubScore(_price);
+            foreach(string s in _upGradeGears)
+            {
+                GameManager.Instance.UpGrade(s);
+            }
+            OverRideBough();
+            Destroy(gameObject);
+        }
+    }
+
+    protected virtual void OverRideBough()
+    {
+
+    }
+}

--- a/Assets/UpGrade.cs
+++ b/Assets/UpGrade.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 public class UpGrade : MonoBehaviour
 {
     [SerializeField] int _price;
-    [SerializeField] string[] _upGradeGears;
+    [SerializeField,Tooltip("強化するギアの名前、複数可")] string[] _upGradeGears;
     [SerializeField] string _UpGradeNameText;
 
     private void Start()

--- a/Assets/UpGrade.cs.meta
+++ b/Assets/UpGrade.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d3dab76b292bf34c86a271b0a876401
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
やったこと
UpGradeの追加,TextMeshPro用にスクリプトを一部変更
一応継承して購入時に追加でなにかさせることもできるはず
ゲーム開始時にScoreと施設リストが変更されていない部分を修正

気になる点
直接ギアの名前を[SerializeField] string で受け取ってるから人間の書き間違いが怖い